### PR TITLE
checking for nil collection and then creating a new one

### DIFF
--- a/lib/connect-loki.js
+++ b/lib/connect-loki.js
@@ -69,7 +69,7 @@ module.exports = (session) => {
 
 		this.client.loadDatabase({}, () => {
 			self.collection = self.client.getCollection('Sessions');
-			if(_.isNil(self.Sessions)) {
+			if(_.isNil(self.collection)) {
 				self.collection = self.client.addCollection('Sessions', {
 					indices: ['sid'],
 					ttlInterval: self.ttl


### PR DESCRIPTION
Bug fix: always creates a new collection. This is problematic when restarting a server, for example.