### PR TITLE
Fixes #3

### DIFF
--- a/lib/connect-loki.js
+++ b/lib/connect-loki.js
@@ -148,7 +148,7 @@ module.exports = (session) => {
 
 	LokiStore.prototype.destroy = function (sid, fn) {
 		if(!fn) { fn = _.noop; }
-		this.collection.remove({ sid });
+		this.collection.findAndRemove({ sid });
 		fn(null);
 	};
 


### PR DESCRIPTION
Loki's `Collection.remove` function removes exactly the object pass in from the collection. We want to remove an object with a match sid. `Collection.findAndRemove` allows us to pass a query and removes all objects that match.