### PR TITLE
fix: cannot read properties of undefined (reading 'findAndRemove')

### DIFF
--- a/lib/connect-loki.js
+++ b/lib/connect-loki.js
@@ -141,7 +141,7 @@ module.exports = (session) => {
    */
   LokiStore.prototype.destroy = function (sid, fn) {
     if (!fn) { fn = _.noop }
-    this.collection.findAndRemove({ sid })
+    if (this.collection) { this.collection.findAndRemove({ sid }) }
     fn(null)
   }
 


### PR DESCRIPTION
Ensures that a collection exists before trying to remove it. Ran into this error on my project:

```sh
Test suite failed to run

    TypeError: Cannot read properties of undefined (reading 'findAndRemove')

      135 |             if (this.store) {
      136 |                     console.log("Session store:", this.store);
    > 137 |                     this.store.destroy();
          |                                ^
      138 |             }
      139 |
      140 |             const finish = (error) => {

      at LokiStore.destroy (../../common/temp/node_modules/.pnpm/connect-loki@1.2.0/node_modules/connect-loki/lib/connect-loki.js:144:21)
      at Core.destroy (src/core.js:137:15)
      at Object.destroy (__tests__/settings.js:23:22)
```